### PR TITLE
Uploading corrected DAS and PtGDA ADLs

### DIFF
--- a/archetypes/openEHR-EHR-OBSERVATION.disease_activity_score_28_crp.v1.adl
+++ b/archetypes/openEHR-EHR-OBSERVATION.disease_activity_score_28_crp.v1.adl
@@ -30,7 +30,7 @@ DAS28-CRP = (0.56*√(TJC)+0.28*√(SJC)+0.36*ln(CRP + 1)+0.014*PtGDA +0.96)">
 		["references"] = <"Anderson J, Caplan L, Yazdany J, Robbins ML, Neogi T, Michaud K, Saag KG, O'dell JR, Kazi S. Rheumatoid arthritis disease activity measures: American College of Rheumatology recommendations for use in clinical practice. Arthritis care & research. 2012 May 1;64(5):640-7.
 
 Wells G, Becker JC, Teng J, Dougados M, Schiff M, Smolen J, Aletaha D, Van Riel PL. Validation of the 28-joint Disease Activity Score (DAS28) and European League Against Rheumatism response criteria based on C-reactive protein against disease progression in patients with rheumatoid arthritis, and comparison with the DAS28 based on erythrocyte sedimentation rate. Annals of the rheumatic diseases. 2009 Jun 1;68(6):954-60.">
-		["MD5-CAM-1.0.1"] = <"E8C25077ADEF23F829B2FA1C9995A207">
+		["MD5-CAM-1.0.1"] = <"49768B73F3F59EA2A28A1DB52F42AF6A">
 	>
 
 definition
@@ -68,7 +68,7 @@ ontology
 			items = <
 				["at0000"] = <
 					text = <"Disease activity score 28-CRP">
-					description = <"Disease activity score 28-CRP (DAS28-CRP) is a calculated score for assessing disease activity in individuals with rheumatoid arthritis (RA). It is calculated from a formula using four parameters: the number of tender (0 - 28) and swollen (0 - 28) joints the patient has, the patient global assessment of disease activity (on a visual analogue scale 0.0 -10.0), and the patient's circulating level of the inflammatory biomarker C-reactive protein (CRP).">
+					description = <"Disease activity score 28-CRP (DAS28-CRP) is a calculated score for assessing disease activity in individuals with rheumatoid arthritis (RA). It is calculated from a formula using four parameters: the number of tender (0 - 28) and swollen (0 - 28) joints the patient has, the patient global assessment of disease activity (on a visual analogue scale 0.0 -100.0), and the patient's circulating level of the inflammatory biomarker C-reactive protein (CRP).">
 				>
 				["at0001"] = <
 					text = <"Event Series">

--- a/archetypes/openEHR-EHR-OBSERVATION.disease_activity_score_28_esr.v1.adl
+++ b/archetypes/openEHR-EHR-OBSERVATION.disease_activity_score_28_esr.v1.adl
@@ -30,7 +30,7 @@ DAS28-ESR = (0.56*√(TJC)+0.28*√(SJC)+0.7*ln(ESR)+0.014*(PtGDA))">
 		["references"] = <"Anderson J, Caplan L, Yazdany J, Robbins ML, Neogi T, Michaud K, Saag KG, O'dell JR, Kazi S. Rheumatoid arthritis disease activity measures: American College of Rheumatology recommendations for use in clinical practice. Arthritis care & research. 2012 May 1;64(5):640-7.
 
 Wells G, Becker JC, Teng J, Dougados M, Schiff M, Smolen J, Aletaha D, Van Riel PL. Validation of the 28-joint Disease Activity Score (DAS28) and European League Against Rheumatism response criteria based on C-reactive protein against disease progression in patients with rheumatoid arthritis, and comparison with the DAS28 based on erythrocyte sedimentation rate. Annals of the rheumatic diseases. 2009 Jun 1;68(6):954-60.">
-		["MD5-CAM-1.0.1"] = <"6BA3D8948640A1B5886025D4A7BDD8E6">
+		["MD5-CAM-1.0.1"] = <"1C44EEC63CC6F2E631DAB90C9225425D">
 	>
 
 definition
@@ -68,7 +68,7 @@ ontology
 			items = <
 				["at0000"] = <
 					text = <"Disease activity score 28-ESR">
-					description = <"Disease activity score 28-ESR (DAS28-ESR) is a calculated score for assessing disease activity in individuals with rheumatoid arthritis (RA). It is calculated from a formula using four parameters: the number of tender (0 - 28) and swollen (0 - 28) joints the patient has, the patient global assessment of disease activity (on a visual analogue scale 0.0 -10.0), and the patient's erythrocyte sedimentation rate (ESR).">
+					description = <"Disease activity score 28-ESR (DAS28-ESR) is a calculated score for assessing disease activity in individuals with rheumatoid arthritis (RA). It is calculated from a formula using four parameters: the number of tender (0 - 28) and swollen (0 - 28) joints the patient has, the patient global assessment of disease activity (on a visual analogue scale 0.0 -100.0), and the patient's erythrocyte sedimentation rate (ESR).">
 				>
 				["at0001"] = <
 					text = <"Event Series">

--- a/archetypes/openEHR-EHR-OBSERVATION.patient_global_assessment_arthritis_activity.v1.adl
+++ b/archetypes/openEHR-EHR-OBSERVATION.patient_global_assessment_arthritis_activity.v1.adl
@@ -16,8 +16,9 @@ description
 		["en"] = <
 			language = <[ISO_639-1::en]>
 			purpose = <"To report the patient's self-assessment of how well they are doing, despite ongoing rheumatoid arthritis.">
-			use = <"Use to record the patient's global assessment of disease activity (PtGDA) using a visual analogue scale (VAS). PtGDA rates the subjective perception of \"how well the patient is doing\" on a VAS between 0.0 = very well (low disease activity) and 10.0 = very poor (high disease activity). The VAS has intervals of 0.5 so that PtGDA can take any of the values: 0.0, 0.5, 1.0, 1.5, 2.0, 2.5 ... 10.0 with unit as 'cm'.
-PtGDA is a component measure in the calculation of simplified disease activity index (SDAI) and clinical disease activity index (CDAI). PtGDA is also a component measure in the calculation of disease activity score (DAS28), but with a VAS between 0.0 = very well (low disease activity) and 100.0 = very poor (high disease activity) with unit as 'mm'.">
+			use = <"Use to record the patient's global assessment of disease activity (PtGDA) using a visual analogue scale (VAS). PtGDA rates the subjective perception of \"how well the patient is doing\" on a VAS between 0.0 = very well (low disease activity) and 10.0 = very poor (high disease activity) with unit as 'cm' OR between 0.0 = very well (low disease activity) and 100.0 = very poor (high disease activity) with unit as 'mm'. The VAS has intervals of 0.5 so that PtGDA can take any of the values: 0.0, 0.5, 1.0, 1.5, 2.0, 2.5 ... 100.0.
+PtGDA is a component measure in the calculation of simplified disease activity index (SDAI) and clinical disease activity index (CDAI), and in both instances the VAS is measured in cm (0 - 10). 
+PtGDA is also a component measure in the calculation of disease activity score (DAS28), where the VAS is measured in mm (0 - 100).">
 			keywords = <"rheumatoid arthritis", "SDAI", "CDAI", "global assessment of disease activity", "DAS28">
 			misuse = <"">
 			copyright = <"© Cambio Healthcare Systems">


### PR DESCRIPTION
Clarified that PtGDA is 0-10cm when used to calculate CDAI and SDAI, and
0-100mm when used to calculate DAS28.